### PR TITLE
[Fix] 상품 Admin 컨트롤러 수정

### DIFF
--- a/src/main/java/io/groom/scubadive/shoppingmall/global/securirty/SecurityConfig.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/global/securirty/SecurityConfig.java
@@ -1,5 +1,6 @@
 package io.groom.scubadive.shoppingmall.global.securirty;
 
+import io.groom.scubadive.shoppingmall.member.domain.enums.Role;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -36,6 +37,7 @@ public class SecurityConfig {
                                 "/ping",
                                 "/h2-console/**"
                         ).permitAll() // 인증 없이 허용할 경로들
+                        .requestMatchers("/api/admin/**").hasRole(Role.ADMIN.name()) // 어드민 롤만 접근 가능.
                         .anyRequest().authenticated() // 나머지는 인증 필요
                 )
                 .headers().frameOptions().disable();

--- a/src/main/java/io/groom/scubadive/shoppingmall/product/controller/ProductAdminController.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/product/controller/ProductAdminController.java
@@ -11,6 +11,7 @@ import io.groom.scubadive.shoppingmall.product.dto.response.ProductWithOptionPag
 import io.groom.scubadive.shoppingmall.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -35,6 +36,7 @@ public class ProductAdminController {
      * @return
      */
     @PostMapping()
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponseDto<ProductSaveResponse> createProduct(@RequestBody ProductSaveRequest request) {
         return productService.createProduct(request);
     }


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 로그인 기능 구현  
- [Fix] 로그인 API 에러 처리  
- [Refactor] 로그인 UI 코드 개선  

---

## 📌 작업 내용 요약
1. 상품 AdminController 에 상품 추가 Response Status 201로 변경
2. 시큐리티 설정에서, 공통 룰로 /api/admin으로 시작하는 api route는 admin role 필요로 변경

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 📎 기타 참고 사항


예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정
