### PR TITLE
feat(user):사용자 정보 수정 기능 구현 (비밀번호 변경 시 로그아웃 처리 포함)

### DIFF
--- a/src/main/java/io/groom/scubadive/shoppingmall/global/exception/ErrorCode.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/global/exception/ErrorCode.java
@@ -14,10 +14,13 @@ public enum ErrorCode {
     INVALID_STATUS_VALUE(HttpStatus.BAD_REQUEST, "상태 값은 'active' 또는 ''만 가능합니다."),
     ALREADY_IN_TARGET_STATUS(HttpStatus.BAD_REQUEST, "이미 해당 상태입니다."),
     USERNAME_NOT_MATCH(HttpStatus.BAD_REQUEST, "사용자 이름이 일치하지 않습니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
+    PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "비밀번호 확인이 필요합니다."),
+    NO_CHANGES_REQUESTED(HttpStatus.BAD_REQUEST, "변경된 정보가 없습니다."),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않았습니다."),
-    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "아이디 혹은 비빌번호가 일치하지 않습니다."),
+    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "아이디 혹은 비밀번호가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     ACCESS_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "AccessToken이 필요합니다."),
     NOT_ADMIN(HttpStatus.UNAUTHORIZED, "관리자 권한이 없습니다."),

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/controller/UserController.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/controller/UserController.java
@@ -5,6 +5,8 @@ import io.groom.scubadive.shoppingmall.global.securirty.LoginUser;
 import io.groom.scubadive.shoppingmall.global.util.CookieUtil;
 import io.groom.scubadive.shoppingmall.member.dto.request.SignInRequest;
 import io.groom.scubadive.shoppingmall.member.dto.request.SignUpRequest;
+import io.groom.scubadive.shoppingmall.member.dto.request.UpdateUserRequest;
+import io.groom.scubadive.shoppingmall.member.dto.response.UpdateUserResponseWrapper;
 import io.groom.scubadive.shoppingmall.member.dto.response.UserInfoResponse;
 import io.groom.scubadive.shoppingmall.member.dto.response.SignInResponse;
 import io.groom.scubadive.shoppingmall.member.dto.response.UserResponse;
@@ -51,5 +53,17 @@ public class UserController {
         UserInfoResponse response = userService.getMyInfo(userId);
         return ResponseEntity.ok(ApiResponseDto.of(200, "내 정보 조회에 성공하였습니다.", response));
     }
+
+
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponseDto<UpdateUserResponseWrapper>> updateMyInfo(
+            @LoginUser Long userId,
+            @Valid @RequestBody UpdateUserRequest request
+    ) {
+        UpdateUserResponseWrapper response = userService.updateMyInfo(userId, request);
+        return ResponseEntity.ok(ApiResponseDto.of(200, "내 정보가 성공적으로 수정되었습니다.", response));
+    }
+
+
 
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/domain/User.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/domain/User.java
@@ -77,13 +77,23 @@ public class User extends BaseTimeEntity {
         this.lastLoginAt = LocalDateTime.now();
     }
 
-    public void updateUserImage(UserImage image) {
-        this.userImage = image;
-    }
 
     public void updateStatus(UserStatus status) {
         this.status = status;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void updatePassword(String newEncodedPassword) {
+        this.password = newEncodedPassword;
+    }
+
 
 
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/dto/request/SignUpRequest.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/dto/request/SignUpRequest.java
@@ -2,6 +2,7 @@ package io.groom.scubadive.shoppingmall.member.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -12,12 +13,14 @@ public class SignUpRequest {
     private String email;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 4, max = 30)
     private String password;
 
     @NotBlank(message = "비밀번호 확인은 필수입니다.")
     private String passwordCheck;
 
     @NotBlank(message = "이름은 필수입니다.")
+    @Size(min = 2, max = 30)
     private String username;
 
     @NotBlank(message = "전화번호는 필수입니다.")

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/dto/request/UpdateUserRequest.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/dto/request/UpdateUserRequest.java
@@ -1,0 +1,28 @@
+package io.groom.scubadive.shoppingmall.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateUserRequest {
+
+    @Size(min = 3, max = 20, message = "닉네임은 3자 이상 20자 이하여야 합니다.")
+    private String nickname;
+
+    private String phoneNumber;
+
+    @Size(min = 4, max = 30, message = "현재 비밀번호는 4자 이상이어야 합니다.")
+    private String currentPassword;
+
+    @Size(min = 4, max = 30, message = "새 비밀번호는 4자 이상이어야 합니다.")
+    private String newPassword;
+
+    @Size(min = 4, max = 30)
+    private String newPasswordCheck;
+
+
+
+}

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/dto/response/UpdateUserResponseWrapper.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/dto/response/UpdateUserResponseWrapper.java
@@ -1,0 +1,11 @@
+package io.groom.scubadive.shoppingmall.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UpdateUserResponseWrapper {
+    private UserInfoResponse user;
+    private boolean loggedOut;
+}

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/repository/UserRepository.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/repository/UserRepository.java
@@ -12,6 +12,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByNickname(String nickname);
 
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
+
     Optional<User> findByEmail(String email);
 
 


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 사용자 정보 수정 기능 구현

---

## 📌 작업 내용 요약

- 사용자 닉네임, 전화번호, 비밀번호 수정 API 구현
- 기존 정보와 동일한 값으로는 수정 불가하도록 검증
- 닉네임 중복 검사 추가
- 비밀번호 변경 시 Refresh Token 삭제 → 강제 로그아웃 처리
- 응답은 UserInfoResponse + loggedOut 여부 포함된 래퍼로 반환

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
Closes #24 

---

## 📎 기타 참고 사항
- 테스트는 Postman으로 수동 확인 완료 (성공/실패/예외 케이스)
- 공통 예외 코드 NICKNAME_ALREADY_EXISTS, PASSWORD_REQUIRED, NO_CHANGES_REQUESTED 추가
- WRONG_PASSWORD 오탈자 수정
