### PR TITLE
feat(user): 로그인 기능 구현

### DIFF
--- a/src/main/java/io/groom/scubadive/shoppingmall/global/util/CookieUtil.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/global/util/CookieUtil.java
@@ -18,4 +18,16 @@ public class CookieUtil {
 
         response.setHeader("Set-Cookie", cookie.toString());
     }
+
+    public static void deleteRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie expiredCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite("Strict")
+                .maxAge(0) // 즉시 만료
+                .build();
+
+        response.setHeader("Set-Cookie", expiredCookie.toString());
+    }
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/controller/UserController.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/controller/UserController.java
@@ -64,6 +64,13 @@ public class UserController {
         return ResponseEntity.ok(ApiResponseDto.of(200, "내 정보가 성공적으로 수정되었습니다.", response));
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponseDto<Void>> logout(@LoginUser Long userId, HttpServletResponse response) {
+        userService.logout(userId, response);
+        return ResponseEntity.ok(ApiResponseDto.of(200, "로그아웃에 성공하였습니다.", null));
+    }
+
+
 
 
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserService.java
@@ -3,6 +3,7 @@ package io.groom.scubadive.shoppingmall.member.service;
 import io.groom.scubadive.shoppingmall.global.exception.ErrorCode;
 import io.groom.scubadive.shoppingmall.global.exception.GlobalException;
 import io.groom.scubadive.shoppingmall.global.securirty.JwtTokenProvider;
+import io.groom.scubadive.shoppingmall.global.util.CookieUtil;
 import io.groom.scubadive.shoppingmall.member.domain.RefreshToken;
 import io.groom.scubadive.shoppingmall.member.domain.User;
 import io.groom.scubadive.shoppingmall.member.domain.UserPaid;
@@ -15,6 +16,7 @@ import io.groom.scubadive.shoppingmall.member.repository.RefreshTokenRepository;
 import io.groom.scubadive.shoppingmall.member.repository.UserPaidRepository;
 import io.groom.scubadive.shoppingmall.member.repository.UserRepository;
 import io.groom.scubadive.shoppingmall.member.util.NicknameGenerator;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -169,7 +171,7 @@ public class UserService {
             }
 
             user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
-            // 비밀번호 변경 시 로그아웃 처리
+            // 비밀번호 변경 시 토큰 무효화
             refreshTokenRepository.deleteById(userId);
             isUpdated = true;
             passwordChanged = true;
@@ -215,5 +217,15 @@ public class UserService {
                 .loggedOut(passwordChanged)
                 .build();
     }
+
+    @Transactional
+    public void logout(Long userId, HttpServletResponse response) {
+        if (userId == null) {
+            throw new GlobalException(ErrorCode.ACCESS_TOKEN_REQUIRED);
+        }
+        refreshTokenRepository.deleteById(userId);
+        CookieUtil.deleteRefreshTokenCookie(response);
+    }
+
 
 }


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 로그아웃 기능 구현

---

## 📌 작업 내용 요약

- 사용자 로그아웃 API 구현 (`POST /api/users/logout`)
- RefreshToken DB에서 삭제
- HttpOnly 쿠키에서 refreshToken 제거

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #30 
---

## 📎 기타 참고 사항

- CookieUtil에 `removeRefreshTokenCookie()` 추가됨
