### PR TITLE
feat(admin-user): 관리자 사용자 전체 조회

### DIFF
--- a/src/main/java/io/groom/scubadive/shoppingmall/global/securirty/SecurityConfig.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/global/securirty/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig {
                                 "/ping",
                                 "/h2-console/**"
                         ).permitAll() // 인증 없이 허용할 경로들
-                        .requestMatchers("/api/users/me").hasAuthority("USER")
+                        .requestMatchers("/api/users/me").hasAnyAuthority("USER", "ADMIN")
+                        .requestMatchers("/api/admin/**").hasAuthority("ADMIN")
                         .anyRequest().authenticated() // 나머지는 인증 필요
                 )
                 .addFilterBefore(jwtAuthenticationFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/controller/UserAdminController.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/controller/UserAdminController.java
@@ -1,4 +1,27 @@
 package io.groom.scubadive.shoppingmall.member.controller;
 
+import io.groom.scubadive.shoppingmall.global.dto.ApiResponseDto;
+import io.groom.scubadive.shoppingmall.member.dto.response.UserAdminResponse;
+import io.groom.scubadive.shoppingmall.member.service.UserAdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/users")
 public class UserAdminController {
+
+    private final UserAdminService userAdminService;
+
+    @GetMapping
+    public ApiResponseDto<Page<UserAdminResponse>> getAllUsers(Pageable pageable) {
+        Page<UserAdminResponse> users = userAdminService.getAllUsers(pageable);
+        return ApiResponseDto.of(200, "사용자 목록 조회에 성공하였습니다.", users);
+    }
+
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/dto/response/UserAdminResponse.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/dto/response/UserAdminResponse.java
@@ -1,0 +1,30 @@
+package io.groom.scubadive.shoppingmall.member.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserAdminResponse {
+    private Long id;
+    private String username;
+    private String nickname;
+    private String email;
+
+    @JsonProperty("phone_number")
+    private String phoneNumber;
+
+    private String role;
+    private String status;
+    private String grade;
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("last_login_at")
+    private LocalDateTime lastLoginAt;
+
+}

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserAdminService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserAdminService.java
@@ -1,0 +1,32 @@
+package io.groom.scubadive.shoppingmall.member.service;
+
+import io.groom.scubadive.shoppingmall.member.dto.response.UserAdminResponse;
+import io.groom.scubadive.shoppingmall.member.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserAdminService {
+
+    private final UserRepository userRepository;
+
+    public Page<UserAdminResponse> getAllUsers(Pageable pageable) {
+        return userRepository.findAll(pageable)
+                .map(user -> UserAdminResponse.builder()
+                        .id(user.getId())
+                        .username(user.getUsername())
+                        .nickname(user.getNickname())
+                        .email(user.getEmail())
+                        .phoneNumber(user.getPhoneNumber())
+                        .role(user.getRole().name())
+                        .status(user.getStatus().name())
+                        .grade(user.getGrade().name())
+                        .createdAt(user.getCreatedAt())
+                        .lastLoginAt(user.getLastLoginAt())
+                        .build());
+    }
+
+}


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 관리자 사용자 전체 조회

---

## 📌 작업 내용 요약

- 관리자 전용 사용자 목록 조회 API (GET /api/admin/users) 구현
- Pageable 기반으로 사용자 목록 조회 및 페이지네이션 처리 (페이지당 10개)
- 사용자 응답 DTO(AdminUserResponse) 설계

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
Related to #32 
---

## 📎 기타 참고 사항

- SecurityConfig 에 관리자 권한 접근 경로 '/api/admin/**' 허용 설정 추가됨
- 정렬 조건 및 검색 기능은 현재 미포함이며  필요 시 확장


