### PR TITLE
feat(admin-user) 사용자 상태 변경 기능 구현

### DIFF
--- a/src/main/java/io/groom/scubadive/shoppingmall/global/securirty/SecurityConfig.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/global/securirty/SecurityConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/controller/UserAdminController.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/controller/UserAdminController.java
@@ -2,14 +2,13 @@ package io.groom.scubadive.shoppingmall.member.controller;
 
 import io.groom.scubadive.shoppingmall.global.dto.ApiResponseDto;
 import io.groom.scubadive.shoppingmall.member.dto.response.UserAdminResponse;
+import io.groom.scubadive.shoppingmall.member.dto.response.UserAdminStatusUpdateResponse;
 import io.groom.scubadive.shoppingmall.member.service.UserAdminService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +21,16 @@ public class UserAdminController {
     public ApiResponseDto<Page<UserAdminResponse>> getAllUsers(Pageable pageable) {
         Page<UserAdminResponse> users = userAdminService.getAllUsers(pageable);
         return ApiResponseDto.of(200, "사용자 목록 조회에 성공하였습니다.", users);
+    }
+
+    @PatchMapping("/{userId}/status")
+    public ResponseEntity<ApiResponseDto<UserAdminStatusUpdateResponse>> updateUserStatus(
+            @PathVariable Long userId
+    ) {
+        UserAdminStatusUpdateResponse response = userAdminService.updateStatus(userId);
+        return ResponseEntity.ok(
+                ApiResponseDto.of(200, "사용자 상태 변경 성공", response)
+        );
     }
 
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/domain/User.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/domain/User.java
@@ -95,5 +95,12 @@ public class User extends BaseTimeEntity {
     }
 
 
+    public boolean isInactiveOverThreeMonths() {
+        if (lastLoginAt == null) return true;
+        return lastLoginAt.isBefore(LocalDateTime.now().minusMonths(3));
+    }
 
+    public void changeStatus(UserStatus userStatus) {
+        this.status = userStatus;
+    }
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/dto/request/AdminUserStatusUpdateRequest.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/dto/request/AdminUserStatusUpdateRequest.java
@@ -1,0 +1,15 @@
+package io.groom.scubadive.shoppingmall.member.dto.request;
+
+import io.groom.scubadive.shoppingmall.member.domain.enums.UserStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminUserStatusUpdateRequest {
+
+    @NotNull(message = "상태값은 필수입니다.")
+    private UserStatus status;
+
+}

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/dto/request/UpdateUserRequest.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/dto/request/UpdateUserRequest.java
@@ -23,6 +23,4 @@ public class UpdateUserRequest {
     @Size(min = 4, max = 30)
     private String newPasswordCheck;
 
-
-
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/dto/response/UserAdminStatusUpdateResponse.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/dto/response/UserAdminStatusUpdateResponse.java
@@ -1,0 +1,28 @@
+package io.groom.scubadive.shoppingmall.member.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.groom.scubadive.shoppingmall.member.domain.enums.Grade;
+import io.groom.scubadive.shoppingmall.member.domain.enums.Role;
+import io.groom.scubadive.shoppingmall.member.domain.enums.UserStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserAdminStatusUpdateResponse {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private UserStatus status;
+    private Grade grade;
+    private Role role;
+
+    @JsonProperty("last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserAdminService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserAdminService.java
@@ -1,11 +1,20 @@
 package io.groom.scubadive.shoppingmall.member.service;
 
+import io.groom.scubadive.shoppingmall.global.exception.ErrorCode;
+import io.groom.scubadive.shoppingmall.global.exception.GlobalException;
+import io.groom.scubadive.shoppingmall.member.domain.User;
+import io.groom.scubadive.shoppingmall.member.domain.enums.UserStatus;
+import io.groom.scubadive.shoppingmall.member.dto.request.AdminUserStatusUpdateRequest;
+import io.groom.scubadive.shoppingmall.member.dto.response.UserAdminStatusUpdateResponse;
 import io.groom.scubadive.shoppingmall.member.dto.response.UserAdminResponse;
 import io.groom.scubadive.shoppingmall.member.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -28,5 +37,38 @@ public class UserAdminService {
                         .lastLoginAt(user.getLastLoginAt())
                         .build());
     }
+
+    @Transactional
+    public UserAdminStatusUpdateResponse updateStatus(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        UserStatus current = user.getStatus();
+
+        switch (current) {
+            case ACTIVE, DORMANT_AUTO -> user.changeStatus(UserStatus.DORMANT_MANUAL);
+
+            case DORMANT_MANUAL -> {
+                if (user.isInactiveOverThreeMonths()) {
+                    user.changeStatus(UserStatus.DORMANT_AUTO);
+                } else {
+                    user.changeStatus(UserStatus.ACTIVE);
+                }
+            }
+        }
+
+        return UserAdminStatusUpdateResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .status(user.getStatus())
+                .grade(user.getGrade())
+                .role(user.getRole())
+                .lastLoginAt(user.getLastLoginAt())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+
+
 
 }


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 사용자 상태 변경 기능 구현

---

## 📌 작업 내용 요약

- 관리자 전용 사용자 상태 변경 API (PATCH /api/admin/users/{userId}/status) 구현
- 상태 변경 로직 반영:
  - ACTIVE → DORMANT_MANUAL
  - DORMANT_MANUAL → ACTIVE (단, 최근 로그인 3개월 초과 시 DORMANT_AUTO)
  - DORMANT_AUTO → DORMANT_MANUAL
- User 도메인에 changeStatus(), isInactiveOverThreeMonths() 메서드 추가

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
Closes #32 


---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정
