### PR TITLE
Feature/user 이메일 중복 확인 API 구현

### DIFF
--- a/src/main/java/io/groom/scubadive/shoppingmall/global/securirty/SecurityConfig.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/global/securirty/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/users/signup",
                                 "/api/users/login",
+                                "/api/users/check-email",
                                 "/api/products/**",
                                 "/api/categories",
                                 "/ping",

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/controller/UserController.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/controller/UserController.java
@@ -32,6 +32,12 @@ public class UserController {
         return ResponseEntity.ok(ApiResponseDto.of(200, "회원가입이 완료되었습니다.", response));
     }
 
+    @GetMapping("/check-email")
+    public ResponseEntity<ApiResponseDto<Void>> checkEmailDuplicate(@RequestParam String email) {
+        userService.validateEmailDuplication(email);
+        return ResponseEntity.ok(ApiResponseDto.of(200, "사용 가능한 이메일입니다.", null));
+    }
+
     @PostMapping("/login")
     public ResponseEntity<ApiResponseDto<SignInResponse>> login(
             @RequestBody @Valid SignInRequest request,

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserService.java
@@ -227,5 +227,11 @@ public class UserService {
         CookieUtil.deleteRefreshTokenCookie(response);
     }
 
+    @Transactional(readOnly = true)
+    public void validateEmailDuplication(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new GlobalException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+    }
 
 }


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 이메일 중복 확인 API 구현

---

## 📌 작업 내용 요약

- GET /api/users/check-email API 구현
- UserService에 이메일 중복 검사 로직 추가 (existsByEmail)
- 중복 시 EMAIL_ALREADY_EXISTS 예외 발생

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
Closes #52

---

## 📎 기타 참고 사항
- Postman 및 FE 연동 테스트 완료
- /api/users/check-email 중복/비중복 케이스 정상 작동 확인