### PR TITLE
Feature/order change status:  배송 완료 시 누적 결제 금액 반영 및 등급 자동 갱신

### DIFF
--- a/src/main/java/io/groom/scubadive/shoppingmall/member/domain/User.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/domain/User.java
@@ -125,6 +125,9 @@ public class User extends BaseTimeEntity {
         this.status = userStatus;
     }
 
-
+    // 사용자 등급 변경
+    public void updateGrade(Grade newGrade) {
+        this.grade = newGrade;
+    }
 }
 

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/repository/UserPaidRepository.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/repository/UserPaidRepository.java
@@ -3,8 +3,10 @@ package io.groom.scubadive.shoppingmall.member.repository;
 import io.groom.scubadive.shoppingmall.member.domain.UserPaid;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserPaidRepository extends JpaRepository<UserPaid, Long> {
 
 
-    UserPaid findByUserId(Long userId);
+    Optional<UserPaid> findByUserId(Long userId);
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserAdminService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserAdminService.java
@@ -32,7 +32,10 @@ public class UserAdminService {
                         .role(user.getRole().name())
                         .status(user.getStatus().name())
                         .grade(user.getGrade().name())
-                        .totalPaid(userPaidRepository.findByUserId(user.getId()).getAmount())
+                        .totalPaid(userPaidRepository.findByUserId(user.getId())
+                                .map(paid -> paid.getAmount())
+                                .orElse(0L))
+
                         .createdAt(user.getCreatedAt())
                         .lastLoginAt(user.getLastLoginAt())
                         .build());

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserPaidService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserPaidService.java
@@ -1,0 +1,22 @@
+package io.groom.scubadive.shoppingmall.member.service;
+
+import io.groom.scubadive.shoppingmall.global.exception.ErrorCode;
+import io.groom.scubadive.shoppingmall.global.exception.GlobalException;
+import io.groom.scubadive.shoppingmall.member.domain.UserPaid;
+import io.groom.scubadive.shoppingmall.member.repository.UserPaidRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserPaidService {
+    private final UserPaidRepository userPaidRepository;
+
+    @Transactional
+    public void addPayment(Long userId, Long amount) {
+        UserPaid userPaid = userPaidRepository.findByUserId(userId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_PAID_NOT_FOUND));
+        userPaid.addPayment(amount); // += amount
+    }
+}

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserService.java
@@ -156,7 +156,11 @@ public class UserService {
                 .status(user.getStatus().name().toLowerCase())
                 .grade(user.getGrade().name())
                 .imagePath(user.getUserImage() != null ? user.getUserImage().getFullImageUrl() : "https://my-shop-image-bucket.s3.ap-northeast-2.amazonaws.com/profile/default_profile.webp")
-                .totalPaid(userPaidRepository.findByUserId(userId).getAmount())
+                .totalPaid(
+                        userPaidRepository.findByUserId(userId)
+                                .map(UserPaid::getAmount)
+                                .orElse(0L)
+                )
                 .lastLoginAt(user.getLastLoginAt())
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())
@@ -256,7 +260,12 @@ public class UserService {
                 .status(user.getStatus().name().toLowerCase())
                 .grade(user.getGrade().name())
                 .imagePath(user.getUserImage() != null ? user.getUserImage().getFullImageUrl() : null)
-                .totalPaid(userPaidRepository.findByUserId(user.getId()).getAmount())
+                .totalPaid(
+                        userPaidRepository.findByUserId(user.getId())
+                                .map(UserPaid::getAmount)
+                                .orElse(0L)
+                )
+
                 .lastLoginAt(user.getLastLoginAt())
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature]  배송 완료 시 누적 결제 금액 반영 및 등급 자동 갱신

---

## 📌 작업 내용 요약

- 주문 상태가 COMPLETED 일 경우 user_paid.amount에 결제 금액 누적
- 누적 금액 기준으로 users.grade 자동 갱신
- UserPaid, User가 없을 경우 예외 처리 추가
- Optional<UserPaid> 처리로 null-safe 리팩터링
- UserInfoResponse, UserAdminResponse에 totalPaid 필드 대응 수정

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #56 

---

## 📎 기타 참고 사항

- 주문 상태가 DELIVERY_COMPLETED일 때만 결제 금액/등급 반영됨
- UserPaidRepository.findByUserId 에 Optional을 도입하여 null-safe하게 리팩터링함
  → UserInfoResponse, UserAdminResponse, UserService, UserAdminService 등 전체적으로 반영됨

