### PR TITLE
feat: 회원가입 시 username 및 password 유효성 검증 추가

### DIFF
--- a/src/main/java/io/groom/scubadive/shoppingmall/global/exception/ErrorCode.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/global/exception/ErrorCode.java
@@ -20,6 +20,9 @@ public enum ErrorCode {
     INVALID_NICKNAME(HttpStatus.BAD_REQUEST,"유효하지 않은 닉네임입니다."),
     INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST,"유효하지 않은 전화번호입니다."),
 
+    INVALID_USERNAME(HttpStatus.BAD_REQUEST, "이름은 한글 2자 이상만 입력 가능합니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호는 영어 소문자, 숫자, 특수문자를 모두 포함해야 합니다."),
+
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않았습니다."),
     WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "아이디 혹은 비밀번호가 일치하지 않습니다."),

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserService.java
@@ -45,11 +45,29 @@ public class UserService {
     public UserResponse signUp(SignUpRequest dto) {
         validateSignUpRequest(dto);
 
+        // 실명 유효성 검사: 한글 2자 이상
+        if (!dto.getUsername().matches("^[가-힣]{2,}$")) {
+            throw new GlobalException(ErrorCode.INVALID_USERNAME);
+        }
+
+        // 비밀번호 형식 검사: 소문자, 숫자, 특수문자 포함 + 8자 이상
+        if (!dto.getPassword().matches("^(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()_+{}\\[\\]:;<>,.?~\\-=/\\\\]).{8,}$")) {
+            throw new GlobalException(ErrorCode.INVALID_PASSWORD_FORMAT);
+        }
+
+        // 비밀번호 일치 여부
+        if (!dto.getPassword().equals(dto.getPasswordCheck())) {
+            throw new GlobalException(ErrorCode.PASSWORDS_DO_NOT_MATCH);
+        }
+
+        // 닉네임 자동 생성 및 중복 방지
         String nickname = generateUniqueNickname();
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
         User user = createUserFromRequest(dto, nickname, encodedPassword);
 
         userRepository.save(user);
+
+        // 초기 UserPaid 엔티티 생성
         userPaidRepository.save(new UserPaid(user));
 
         return new UserResponse(user.getId(), user.getEmail(), user.getNickname());


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 회원가입 시 username 및 password 유효성 검사 추가

---

## 📌 작업 내용 요약
- 회원가입 시 이름은 한글 2자 이상, 비밀번호는 소문자+숫자+특수문자 포함 8자 이상 유효성 검증 추가
- ErrorCode에 관련 에러 코드 추가 (INVALID_USERNAME, INVALID_PASSWORD)

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #59 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정
