### PR TITLE
Fix SecurityContext 인증 구조에 맞게 인증 방식 수정 및 주문 상태 예외 처리 추가

### DIFF
--- a/src/main/java/io/groom/scubadive/shoppingmall/global/exception/ErrorCode.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     NO_CHANGES_REQUESTED(HttpStatus.BAD_REQUEST, "변경된 정보가 없습니다."),
     INVALID_NICKNAME(HttpStatus.BAD_REQUEST,"유효하지 않은 닉네임입니다."),
     INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST,"유효하지 않은 전화번호입니다."),
+    ALREADY_COMPLETED_ORDER(HttpStatus.BAD_REQUEST,"이미 완료된 주문입니다."),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않았습니다."),

--- a/src/main/java/io/groom/scubadive/shoppingmall/global/securirty/JwtAuthenticationFilter.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/global/securirty/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package io.groom.scubadive.shoppingmall.global.securirty;
 
+import io.groom.scubadive.shoppingmall.member.domain.User;
+import io.groom.scubadive.shoppingmall.member.repository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,6 +22,7 @@ import java.util.List;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -35,6 +38,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (jwtTokenProvider.validateToken(token)) {
                 Long userId = jwtTokenProvider.getUserIdFromToken(token);
                 String role = jwtTokenProvider.getRoleFromToken(token);
+
+                User user = userRepository.findById(userId)
+                        .orElseThrow(() -> new IllegalStateException("인증된 사용자를 찾을 수 없습니다."));
 
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(

--- a/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/member/service/UserService.java
@@ -168,6 +168,16 @@ public class UserService {
     }
 
     /**
+     * 사용자 엔티티 조회 (비즈니스 로직용)
+     * - 주문, 결제 등에서 User 객체가 필요할 때 사용
+     * - Service 내부 도메인 로직 처리에 활용
+     */
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
      * 내 정보 수정 - 비밀번호/닉네임/전화번호 변경
      * 변경된 항목이 없으면 예외 발생
      */

--- a/src/main/java/io/groom/scubadive/shoppingmall/order/controller/OrderController.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package io.groom.scubadive.shoppingmall.order.controller;
 
 import io.groom.scubadive.shoppingmall.global.dto.ApiResponseDto;
+import io.groom.scubadive.shoppingmall.global.securirty.LoginUser;
 import io.groom.scubadive.shoppingmall.member.domain.User;
 import io.groom.scubadive.shoppingmall.order.dto.request.OrderCreateRequest;
 import io.groom.scubadive.shoppingmall.order.dto.response.OrderListResponse;
@@ -31,9 +32,9 @@ public class OrderController {
     })
     @PostMapping
     public ResponseEntity<ApiResponseDto<OrderResponse>> createOrder(
-            @AuthenticationPrincipal User user,
+            @LoginUser Long userId,
             @RequestBody OrderCreateRequest request) {
-        OrderResponse response = orderService.createOrder(user, request);
+        OrderResponse response = orderService.createOrder(userId, request);
         return ResponseEntity.status(201).body(ApiResponseDto.of(201, "주문 생성 성공", response));
     }
 
@@ -55,10 +56,10 @@ public class OrderController {
     })
     @GetMapping
     public ResponseEntity<ApiResponseDto<OrderListResponse>> getUserOrders(
-            @AuthenticationPrincipal User user,
+            @LoginUser Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-        OrderListResponse response = orderService.getUserOrders(user, page, size);
+        OrderListResponse response = orderService.getUserOrders(userId, page, size);
         return ResponseEntity.ok(ApiResponseDto.of(200, "사용자 주문 목록 조회 성공", response));
     }
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/order/service/OrderService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/order/service/OrderService.java
@@ -3,6 +3,8 @@ package io.groom.scubadive.shoppingmall.order.service;
 import io.groom.scubadive.shoppingmall.cart.domain.Cart;
 import io.groom.scubadive.shoppingmall.cart.domain.CartItem;
 import io.groom.scubadive.shoppingmall.cart.repository.CartRepository;
+import io.groom.scubadive.shoppingmall.global.exception.ErrorCode;
+import io.groom.scubadive.shoppingmall.global.exception.GlobalException;
 import io.groom.scubadive.shoppingmall.member.domain.User;
 import io.groom.scubadive.shoppingmall.member.service.UserPaidService;
 import io.groom.scubadive.shoppingmall.member.service.UserService;
@@ -30,8 +32,10 @@ public class OrderService {
     private final UserService userService;
 
     @Transactional
-    public OrderResponse createOrder(User user, OrderCreateRequest request) {
-        Cart cart = cartRepository.findById(request.getCartId()).orElseThrow();
+    public OrderResponse createOrder(Long userId, OrderCreateRequest request) {
+        User user = userService.getUserById(userId);
+        Cart cart = cartRepository.findById(request.getCartId())
+                .orElseThrow(() -> new IllegalArgumentException("장바구니를 찾을 수 없습니다."));
 
         if (cart.getItems().isEmpty()) throw new IllegalStateException("장바구니가 비어있습니다.");
 
@@ -58,8 +62,8 @@ public class OrderService {
         return mapToOrderResponse(order);
     }
 
-    public OrderListResponse getUserOrders(User user, int page, int size) {
-        Page<Order> orders = orderRepository.findAllByUserId(user.getId(), PageRequest.of(page, size));
+    public OrderListResponse getUserOrders(Long userId, int page, int size) {
+        Page<Order> orders = orderRepository.findAllByUserId(userId, PageRequest.of(page, size));
         return OrderListResponse.builder()
                 .page(page)
                 .totalPages(orders.getTotalPages())

--- a/src/main/java/io/groom/scubadive/shoppingmall/order/service/OrderService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/order/service/OrderService.java
@@ -98,6 +98,9 @@ public class OrderService {
     public void changeStatus(Long orderId, OrderStatus status) {
         Order order = orderRepository.findById(orderId).orElseThrow();
         OrderStatus previousStatus = order.getStatus();
+        if (previousStatus == OrderStatus.COMPLETED) {
+            throw new GlobalException(ErrorCode.ALREADY_COMPLETED_ORDER);
+        }
 
         order.changeStatus(status);
 


### PR DESCRIPTION
## 🔀 PR 제목
- [Fix] SecurityContext 인증 구조에 맞게 인증 방식 수정
- [Feature] 주문 상태 예외 처리 추가

---

## 📌 작업 내용 요약

- 기존 @AuthenticationPrincipal User 방식 → @LoginUser Long userId로 변경
- 서비스 계층에서 userService.getUserById(userId)로 명시적 조회
- 주문 상태가 이미 COMPLETED인 경우, 상태 변경 시 예외 발생하도록 처리
- 관련 예외 코드 및 메시지 정의

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
Closes #61 


---

## 📎 기타 참고 사항

- 테스트 주문 흐름 정상 동작 및 등급 반영까지 확인 완료

