### PR TITLE
Fix/stats

### DIFF
--- a/src/main/java/io/groom/scubadive/shoppingmall/ShoppingmallApplication.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/ShoppingmallApplication.java
@@ -3,9 +3,11 @@ package io.groom.scubadive.shoppingmall;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class ShoppingmallApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/io/groom/scubadive/shoppingmall/global/exception/ErrorCode.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/global/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     INVALID_USERNAME(HttpStatus.BAD_REQUEST, "이름은 한글 2자 이상만 입력 가능합니다."),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호는 영어 소문자, 숫자, 특수문자를 모두 포함해야 합니다."),
     INVALID_ORDER_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "잘못된 주문 상태 변경 요청입니다."),
+    STATS_NOT_FOUND(HttpStatus.BAD_REQUEST, "통계 정보가 존재하지 않습니다."),
+    PRODUCT_SALES_RANKING_NOT_FOUND(HttpStatus.BAD_REQUEST, "상품 판매 랭킹 정보가 존재하지 않습니다."),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않았습니다."),

--- a/src/main/java/io/groom/scubadive/shoppingmall/order/domain/Order.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/order/domain/Order.java
@@ -33,7 +33,7 @@ public class Order extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> items = new ArrayList<>();
 
     public Order(User user, String orderNumber, int totalQuantity, Long totalAmount, OrderStatus status) {

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/controller/StatsController.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/controller/StatsController.java
@@ -49,14 +49,14 @@ public class StatsController {
         RecentStatsResponse result = statsService.getRecentStats();
         return ResponseEntity.ok(ApiResponseDto.of(200, "최근 3일 통계 조회 성공", result));
     }
-//
-//    @Operation(summary = "상품 판매 순위 조회", description = "오늘의 상품별 판매 순위를 조회합니다.")
-//    @ApiResponse(responseCode = "200", description = "상품 판매 순위 조회 성공")
-//    @GetMapping("/top-products")
-//    public ResponseEntity<ApiResponseDto<TopProductsResponse>> getTopProducts() {
-//        TopProductsResponse result = statsService.getTopProducts();
-//        return ResponseEntity.ok(ApiResponseDto.of(200, "오늘 상품 판매 순위 조회 성공", result));
-//    }
+
+    @Operation(summary = "상품 판매 순위 조회", description = "오늘의 상품별 판매 순위를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "상품 판매 순위 조회 성공")
+    @GetMapping("/top-products")
+    public ResponseEntity<ApiResponseDto<TopProductsResponse>> getTopProducts() {
+        TopProductsResponse result = statsService.getTopProducts();
+        return ResponseEntity.ok(ApiResponseDto.of(200, "오늘 상품 판매 순위 조회 성공", result));
+    }
 
     @PostMapping("/daily")
     public ResponseEntity<String> saveDailyStats(@RequestParam(defaultValue = "2") int daysAgo) {

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/controller/StatsController.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/controller/StatsController.java
@@ -36,19 +36,19 @@ public class StatsController {
         return ResponseEntity.ok(ApiResponseDto.of(200, "오늘 통계 조회 성공", result));
     }
 
-    @Operation(summary = "최근 3일 통계 조회", description = "최근 3일간의 일별 매출 및 주문 수를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "최근 통계 조회 성공")
-    @GetMapping("/recent")
-    public ResponseEntity<ApiResponseDto<RecentStatsResponse>> getRecentStats() {
-        RecentStatsResponse result = statsService.getRecentStats();
-        return ResponseEntity.ok(ApiResponseDto.of(200, "최근 3일 통계 조회 성공", result));
-    }
-
-    @Operation(summary = "상품 판매 순위 조회", description = "오늘의 상품별 판매 순위를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "상품 판매 순위 조회 성공")
-    @GetMapping("/top-products")
-    public ResponseEntity<ApiResponseDto<TopProductsResponse>> getTopProducts() {
-        TopProductsResponse result = statsService.getTopProducts();
-        return ResponseEntity.ok(ApiResponseDto.of(200, "오늘 상품 판매 순위 조회 성공", result));
-    }
+//    @Operation(summary = "최근 3일 통계 조회", description = "최근 3일간의 일별 매출 및 주문 수를 조회합니다.")
+//    @ApiResponse(responseCode = "200", description = "최근 통계 조회 성공")
+//    @GetMapping("/recent")
+//    public ResponseEntity<ApiResponseDto<RecentStatsResponse>> getRecentStats() {
+//        RecentStatsResponse result = statsService.getRecentStats();
+//        return ResponseEntity.ok(ApiResponseDto.of(200, "최근 3일 통계 조회 성공", result));
+//    }
+//
+//    @Operation(summary = "상품 판매 순위 조회", description = "오늘의 상품별 판매 순위를 조회합니다.")
+//    @ApiResponse(responseCode = "200", description = "상품 판매 순위 조회 성공")
+//    @GetMapping("/top-products")
+//    public ResponseEntity<ApiResponseDto<TopProductsResponse>> getTopProducts() {
+//        TopProductsResponse result = statsService.getTopProducts();
+//        return ResponseEntity.ok(ApiResponseDto.of(200, "오늘 상품 판매 순위 조회 성공", result));
+//    }
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/controller/StatsController.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/controller/StatsController.java
@@ -4,7 +4,6 @@ import io.groom.scubadive.shoppingmall.global.dto.ApiResponseDto;
 import io.groom.scubadive.shoppingmall.stats.dto.response.RecentStatsResponse;
 import io.groom.scubadive.shoppingmall.stats.dto.response.TodayStatsResponse;
 import io.groom.scubadive.shoppingmall.stats.dto.response.TopProductsResponse;
-import io.groom.scubadive.shoppingmall.stats.scheduler.StatsScheduler;
 import io.groom.scubadive.shoppingmall.stats.service.StatsCommandService;
 import io.groom.scubadive.shoppingmall.stats.service.StatsQueryService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/controller/StatsController.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/controller/StatsController.java
@@ -4,6 +4,8 @@ import io.groom.scubadive.shoppingmall.global.dto.ApiResponseDto;
 import io.groom.scubadive.shoppingmall.stats.dto.response.RecentStatsResponse;
 import io.groom.scubadive.shoppingmall.stats.dto.response.TodayStatsResponse;
 import io.groom.scubadive.shoppingmall.stats.dto.response.TopProductsResponse;
+import io.groom.scubadive.shoppingmall.stats.scheduler.StatsScheduler;
+import io.groom.scubadive.shoppingmall.stats.service.StatsCommandService;
 import io.groom.scubadive.shoppingmall.stats.service.StatsQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -12,6 +14,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @CrossOrigin(
         origins = {
@@ -27,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 public class StatsController {
 
     private final StatsQueryService statsService;
+    private final StatsCommandService statsCommandService;
 
     @Operation(summary = "오늘 통계 조회", description = "오늘의 총 매출 및 주문 수를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "오늘 통계 조회 성공")
@@ -36,13 +42,13 @@ public class StatsController {
         return ResponseEntity.ok(ApiResponseDto.of(200, "오늘 통계 조회 성공", result));
     }
 
-//    @Operation(summary = "최근 3일 통계 조회", description = "최근 3일간의 일별 매출 및 주문 수를 조회합니다.")
-//    @ApiResponse(responseCode = "200", description = "최근 통계 조회 성공")
-//    @GetMapping("/recent")
-//    public ResponseEntity<ApiResponseDto<RecentStatsResponse>> getRecentStats() {
-//        RecentStatsResponse result = statsService.getRecentStats();
-//        return ResponseEntity.ok(ApiResponseDto.of(200, "최근 3일 통계 조회 성공", result));
-//    }
+    @Operation(summary = "최근 3일 통계 조회", description = "최근 3일간의 일별 매출 및 주문 수를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "최근 통계 조회 성공")
+    @GetMapping("/recent")
+    public ResponseEntity<ApiResponseDto<RecentStatsResponse>> getRecentStats() {
+        RecentStatsResponse result = statsService.getRecentStats();
+        return ResponseEntity.ok(ApiResponseDto.of(200, "최근 3일 통계 조회 성공", result));
+    }
 //
 //    @Operation(summary = "상품 판매 순위 조회", description = "오늘의 상품별 판매 순위를 조회합니다.")
 //    @ApiResponse(responseCode = "200", description = "상품 판매 순위 조회 성공")
@@ -51,4 +57,15 @@ public class StatsController {
 //        TopProductsResponse result = statsService.getTopProducts();
 //        return ResponseEntity.ok(ApiResponseDto.of(200, "오늘 상품 판매 순위 조회 성공", result));
 //    }
+
+    @PostMapping("/daily")
+    public ResponseEntity<String> saveDailyStats(@RequestParam(defaultValue = "2") int daysAgo) {
+        LocalDate targetDate = LocalDate.now().minusDays(daysAgo);
+        LocalDateTime start = targetDate.atStartOfDay();
+        LocalDateTime end = targetDate.atTime(23, 59, 59, 999_999_999);
+
+        statsCommandService.saveDailyStats(start, end, targetDate);
+        return ResponseEntity.ok("✅ " + targetDate + " DailyStats 저장 완료");
+    }
+
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/domain/DailyStats.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/domain/DailyStats.java
@@ -3,7 +3,7 @@ package io.groom.scubadive.shoppingmall.stats.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -16,7 +16,7 @@ public class DailyStats {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private LocalDateTime timestamp;
+    private LocalDate date; // 예: 2025-07-06
 
     private long totalSales;
 

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/domain/HourlyStats.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/domain/HourlyStats.java
@@ -1,0 +1,28 @@
+package io.groom.scubadive.shoppingmall.stats.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class HourlyStats {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    private long totalSales;
+    private int totalOrders;
+}
+

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/domain/ProductSalesRanking.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/domain/ProductSalesRanking.java
@@ -7,7 +7,6 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -25,5 +24,6 @@ public class ProductSalesRanking {
 
     private Long totalSales;
 
+    @Setter
     private Integer ranking;
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/dto/response/TopProductsResponse.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/dto/response/TopProductsResponse.java
@@ -25,7 +25,7 @@ public class TopProductsResponse {
         @Schema(description = "순위", example = "1")
         private int rank;
 
-        @Schema(description = "상품명", example = "스쿠버 장비 세트")
+        @Schema(description = "상품명", example = "푹신한 의자")
         private String productName;
 
         @Schema(description = "총 판매 금액", example = "1250000")

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/repository/DailyStatsRepository.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/repository/DailyStatsRepository.java
@@ -2,23 +2,13 @@ package io.groom.scubadive.shoppingmall.stats.repository;
 
 import io.groom.scubadive.shoppingmall.stats.domain.DailyStats;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 public interface DailyStatsRepository extends JpaRepository<DailyStats, Long> {
+    boolean existsByDate(LocalDate date);
 
-    Optional<DailyStats> findTopByOrderByTimestampDesc();
-
-    List<DailyStats> findByTimestampBetween(LocalDateTime start, LocalDateTime end);
-
-    @Modifying
-    @Query("DELETE FROM DailyStats d WHERE d.timestamp >= :start AND d.timestamp <= :end")
-    void deleteByDate(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+    List<DailyStats> findByDateBetweenOrderByDateAsc(LocalDate from, LocalDate to);
 
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/repository/DailyStatsRepository.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/repository/DailyStatsRepository.java
@@ -2,7 +2,11 @@ package io.groom.scubadive.shoppingmall.stats.repository;
 
 import io.groom.scubadive.shoppingmall.stats.domain.DailyStats;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +16,9 @@ public interface DailyStatsRepository extends JpaRepository<DailyStats, Long> {
     Optional<DailyStats> findTopByOrderByTimestampDesc();
 
     List<DailyStats> findByTimestampBetween(LocalDateTime start, LocalDateTime end);
+
+    @Modifying
+    @Query("DELETE FROM DailyStats d WHERE d.timestamp >= :start AND d.timestamp <= :end")
+    void deleteByDate(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/repository/HourlyStatsRepository.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/repository/HourlyStatsRepository.java
@@ -1,0 +1,15 @@
+package io.groom.scubadive.shoppingmall.stats.repository;
+
+import io.groom.scubadive.shoppingmall.stats.domain.HourlyStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface HourlyStatsRepository extends JpaRepository<HourlyStats, Long> {
+
+    List<HourlyStats> findByStartTimeBetween(LocalDateTime start, LocalDateTime end);
+
+    boolean existsByStartTimeAndEndTime(LocalDateTime start, LocalDateTime end);
+}
+

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/repository/ProductSalesRankingRepository.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/repository/ProductSalesRankingRepository.java
@@ -7,7 +7,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface ProductSalesRankingRepository extends JpaRepository<ProductSalesRanking, Long> {
-    List<ProductSalesRanking> findByDateOrderByTotalSalesDesc(LocalDate date);
+    List<ProductSalesRanking> findByDate(LocalDate date);
 
     List<ProductSalesRanking> findByDateOrderByTotalQuantityDesc(LocalDate date);
     void deleteByDate(LocalDate date);

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/repository/ProductSalesRankingRepository.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/repository/ProductSalesRankingRepository.java
@@ -9,6 +9,5 @@ import java.util.List;
 public interface ProductSalesRankingRepository extends JpaRepository<ProductSalesRanking, Long> {
     List<ProductSalesRanking> findByDate(LocalDate date);
 
-    List<ProductSalesRanking> findByDateOrderByTotalQuantityDesc(LocalDate date);
     void deleteByDate(LocalDate date);
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/scheduler/StatsScheduler.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/scheduler/StatsScheduler.java
@@ -60,5 +60,15 @@ public class StatsScheduler {
         }
     }
 
-
+    @Scheduled(cron = "0 0,30 * * * *") // 매 시각 00분, 30분마다 실행
+//    @Scheduled(cron = "*/10 * * * * *")
+    public void updateTodayProductRankings() {
+        LocalDate today = LocalDate.now();
+        try {
+            statsCommandService.saveTopProductRankings(today);
+            log.info("[스케줄러] ✅ 오늘의 상품 판매 랭킹 저장 완료: {}", today);
+        } catch (Exception e) {
+            log.error("[스케줄러] ❌ 오늘의 상품 판매 랭킹 저장 실패: {}", today, e);
+        }
+    }
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/scheduler/StatsScheduler.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/scheduler/StatsScheduler.java
@@ -46,5 +46,19 @@ public class StatsScheduler {
         }
     }
 
+    @Scheduled(cron = "0 5 0 * * *") // 매일 자정 5분 후 실행
+    public void saveDailyStatsFromHourlyStats() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        LocalDateTime start = yesterday.atStartOfDay();         // 어제 00:00
+        LocalDateTime end = yesterday.atTime(23, 59, 59, 999_999_999); // 어제 23:59:59.999999999
+
+        try {
+            statsCommandService.saveDailyStats(start, end, yesterday);
+            log.info("[스케줄러] ✅ 어제 일일 매출 저장 완료: {}", yesterday);
+        } catch (Exception e) {
+            log.error("[스케줄러] ❌ 어제 일일 매출 저장 실패: {}", yesterday, e);
+        }
+    }
+
 
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/service/StatsCommandService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/service/StatsCommandService.java
@@ -3,6 +3,7 @@ package io.groom.scubadive.shoppingmall.stats.service;
 import io.groom.scubadive.shoppingmall.order.domain.Order;
 import io.groom.scubadive.shoppingmall.order.domain.OrderItem;
 import io.groom.scubadive.shoppingmall.order.repository.OrderRepository;
+import io.groom.scubadive.shoppingmall.product.domain.Product;
 import io.groom.scubadive.shoppingmall.stats.domain.DailyStats;
 import io.groom.scubadive.shoppingmall.stats.domain.HourlyStats;
 import io.groom.scubadive.shoppingmall.stats.domain.ProductSalesRanking;
@@ -10,15 +11,16 @@ import io.groom.scubadive.shoppingmall.stats.repository.DailyStatsRepository;
 import io.groom.scubadive.shoppingmall.stats.repository.HourlyStatsRepository;
 import io.groom.scubadive.shoppingmall.stats.repository.ProductSalesRankingRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class StatsCommandService {
@@ -67,5 +69,64 @@ public class StatsCommandService {
         dailyStatsRepository.save(dailyStats);
     }
 
+
+    @Transactional
+    public void saveTopProductRankings(LocalDate date) {
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.atTime(23, 59, 59, 999_999_999);
+
+        // 1. 날짜 범위 기준으로 주문 조회
+        List<Order> orders = orderRepository.findByCreatedAtBetween(start, end);
+        log.info("🔍 {} 기준 주문 개수: {}", date, orders.size());
+
+        // 2. 주문에 포함된 모든 아이템 수집
+        List<OrderItem> orderItems = orders.stream()
+                .flatMap(order -> order.getItems().stream())
+                .collect(Collectors.toList());
+        log.info("🔎 {} 기준 OrderItem 개수: {}", date, orderItems.size());
+
+        // 3. 상품 기준 그룹핑
+        Map<Product, List<OrderItem>> grouped = orderItems.stream()
+                .filter(item -> item.getProductOption() != null && item.getProductOption().getProduct() != null)
+                .collect(Collectors.groupingBy(item -> item.getProductOption().getProduct()));
+
+        log.info("🔧 상품별 그룹핑 결과: {}", grouped.keySet().stream()
+                .map(Product::getProductName)
+                .collect(Collectors.toList()));
+
+        // 4. 집계 및 정렬
+        List<ProductSalesRanking> rankings = grouped.entrySet().stream()
+                .map(entry -> {
+                    Product product = entry.getKey();
+                    List<OrderItem> items = entry.getValue();
+
+                    int totalQuantity = items.stream().mapToInt(OrderItem::getQuantity).sum();
+                    long totalSales = items.stream()
+                            .mapToLong(item -> item.getQuantity() * product.getPrice())
+                            .sum();
+
+                    return ProductSalesRanking.builder()
+                            .date(date)
+                            .productName(product.getProductName())
+                            .totalQuantity(totalQuantity)
+                            .totalSales(totalSales)
+                            .build();
+                })
+                .sorted(Comparator.comparing(ProductSalesRanking::getTotalSales).reversed())
+                .collect(Collectors.toList());
+
+        log.info("📊 총 {}개 상품의 판매 랭킹 계산 완료", rankings.size());
+
+        // 5. 순위 부여
+        for (int i = 0; i < rankings.size(); i++) {
+            rankings.get(i).setRanking(i + 1);
+            ProductSalesRanking r = rankings.get(i);
+            log.info("🏷️ 순위 {}: {}, 수량: {}, 매출: {}", r.getRanking(), r.getProductName(), r.getTotalQuantity(), r.getTotalSales());
+        }
+
+        // 6. 기존 랭킹 삭제 후 저장
+        productSalesRankingRepository.deleteByDate(date);
+        productSalesRankingRepository.saveAll(rankings);
+    }
 
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/service/StatsCommandService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/service/StatsCommandService.java
@@ -82,7 +82,7 @@ public class StatsCommandService {
         // 2. 주문에 포함된 모든 아이템 수집
         List<OrderItem> orderItems = orders.stream()
                 .flatMap(order -> order.getItems().stream())
-                .collect(Collectors.toList());
+                .toList();
         log.info("🔎 {} 기준 OrderItem 개수: {}", date, orderItems.size());
 
         // 3. 상품 기준 그룹핑
@@ -94,7 +94,7 @@ public class StatsCommandService {
                 .map(Product::getProductName)
                 .collect(Collectors.toList()));
 
-        // 4. 집계 및 정렬
+        // 4. 집계 및 정렬 후 상위 5개만 추출
         List<ProductSalesRanking> rankings = grouped.entrySet().stream()
                 .map(entry -> {
                     Product product = entry.getKey();
@@ -113,6 +113,7 @@ public class StatsCommandService {
                             .build();
                 })
                 .sorted(Comparator.comparing(ProductSalesRanking::getTotalSales).reversed())
+                .limit(5)
                 .collect(Collectors.toList());
 
         log.info("📊 총 {}개 상품의 판매 랭킹 계산 완료", rankings.size());

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/service/StatsCommandService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/service/StatsCommandService.java
@@ -6,7 +6,7 @@ import io.groom.scubadive.shoppingmall.order.repository.OrderRepository;
 import io.groom.scubadive.shoppingmall.stats.domain.DailyStats;
 import io.groom.scubadive.shoppingmall.stats.domain.HourlyStats;
 import io.groom.scubadive.shoppingmall.stats.domain.ProductSalesRanking;
-//import io.groom.scubadive.shoppingmall.stats.repository.DailyStatsRepository;
+import io.groom.scubadive.shoppingmall.stats.repository.DailyStatsRepository;
 import io.groom.scubadive.shoppingmall.stats.repository.HourlyStatsRepository;
 import io.groom.scubadive.shoppingmall.stats.repository.ProductSalesRankingRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class StatsCommandService {
 
     private final OrderRepository orderRepository;
     private final HourlyStatsRepository hourlyStatsRepository;
-//    private final DailyStatsRepository dailyStatsRepository;
+    private final DailyStatsRepository dailyStatsRepository;
     private final ProductSalesRankingRepository productSalesRankingRepository;
 
     @Transactional
@@ -47,6 +47,24 @@ public class StatsCommandService {
                 .build();
 
         hourlyStatsRepository.save(stats);
+    }
+
+    @Transactional
+    public void saveDailyStats(LocalDateTime start, LocalDateTime end, LocalDate date) {
+        if (dailyStatsRepository.existsByDate(date)) return;
+
+        List<HourlyStats> hourlyStatsList = hourlyStatsRepository.findByStartTimeBetween(start, end);
+
+        long totalSales = hourlyStatsList.stream().mapToLong(HourlyStats::getTotalSales).sum();
+        int totalOrders = hourlyStatsList.stream().mapToInt(HourlyStats::getTotalOrders).sum();
+
+        DailyStats dailyStats = DailyStats.builder()
+                .date(date)
+                .totalSales(totalSales)
+                .totalOrders(totalOrders)
+                .build();
+
+        dailyStatsRepository.save(dailyStats);
     }
 
 

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/service/StatsQueryService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/service/StatsQueryService.java
@@ -1,68 +1,95 @@
-// StatsQueryService.java
 package io.groom.scubadive.shoppingmall.stats.service;
 
+import io.groom.scubadive.shoppingmall.global.exception.ErrorCode;
+import io.groom.scubadive.shoppingmall.global.exception.GlobalException;
 import io.groom.scubadive.shoppingmall.stats.domain.DailyStats;
+import io.groom.scubadive.shoppingmall.stats.domain.HourlyStats;
 import io.groom.scubadive.shoppingmall.stats.domain.ProductSalesRanking;
 import io.groom.scubadive.shoppingmall.stats.dto.response.RecentStatsResponse;
 import io.groom.scubadive.shoppingmall.stats.dto.response.TodayStatsResponse;
 import io.groom.scubadive.shoppingmall.stats.dto.response.TopProductsResponse;
-import io.groom.scubadive.shoppingmall.stats.repository.DailyStatsRepository;
+import io.groom.scubadive.shoppingmall.stats.repository.HourlyStatsRepository;
 import io.groom.scubadive.shoppingmall.stats.repository.ProductSalesRankingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class StatsQueryService {
 
-    private final DailyStatsRepository dailyStatsRepository;
+    private final HourlyStatsRepository hourlyStatsRepository;
     private final ProductSalesRankingRepository productSalesRankingRepository;
 
     public TodayStatsResponse getTodayStats() {
-        DailyStats stats = dailyStatsRepository.findTopByOrderByTimestampDesc()
-                .orElseThrow(() -> new IllegalStateException("오늘 통계가 존재하지 않습니다."));
+        LocalDateTime start = LocalDate.now().atStartOfDay();         // 오늘 00:00
+        LocalDateTime end = LocalDateTime.now();                      // 지금 시각
 
-        return new TodayStatsResponse(stats.getTotalSales(), stats.getTotalOrders(), stats.getTimestamp());
+        List<HourlyStats> stats = hourlyStatsRepository.findByStartTimeBetween(start, end);
+
+        long totalSales = stats.stream().mapToLong(HourlyStats::getTotalSales).sum();
+        int totalOrders = stats.stream().mapToInt(HourlyStats::getTotalOrders).sum();
+
+        return new TodayStatsResponse(totalSales, totalOrders, end);
     }
 
-    public RecentStatsResponse getRecentStats() {
-        LocalDate today = LocalDate.now();
-        List<DailyStats> recent = dailyStatsRepository.findByTimestampBetween(
-                today.minusDays(3).atStartOfDay(),
-                today.minusDays(1).atTime(LocalTime.MAX)
-        );
 
-        List<RecentStatsResponse.SalesStats> list = recent.stream()
-                .map(stat -> new RecentStatsResponse.SalesStats(
-                        stat.getTimestamp().toLocalDate(),  // 수정 포인트
-                        stat.getTotalSales(),
-                        stat.getTotalOrders()))
-                .collect(Collectors.toList());
-
-        return new RecentStatsResponse(list);
-    }
-
-    public TopProductsResponse getTopProducts() {
-        LocalDate today = LocalDate.now();
-
-        List<ProductSalesRanking> salesRankingsRaw = productSalesRankingRepository.findByDateOrderByTotalSalesDesc(today);
-        List<ProductSalesRanking> quantityRankingsRaw = productSalesRankingRepository.findByDateOrderByTotalQuantityDesc(today);
-
-        List<TopProductsResponse.ProductRanking> salesRankings = salesRankingsRaw.stream()
-                .limit(5)
-                .map(r -> new TopProductsResponse.ProductRanking(r.getRanking(), r.getProductName(), r.getTotalSales(), r.getTotalQuantity()))
-                .collect(Collectors.toList());
-
-        List<TopProductsResponse.ProductRanking> quantityRankings = quantityRankingsRaw.stream()
-                .limit(5)
-                .map(r -> new TopProductsResponse.ProductRanking(r.getRanking(), r.getProductName(), r.getTotalSales(), r.getTotalQuantity()))
-                .collect(Collectors.toList());
-
-        return new TopProductsResponse(salesRankings, quantityRankings);
-    }
+//    public RecentStatsResponse getRecentStats() {
+//        LocalDate today = LocalDate.now();
+//        List<DailyStats> recent = dailyStatsRepository.findByTimestampBetween(
+//                today.minusDays(3).atStartOfDay(),  // 오늘 포함 최근 3일
+//                today.atTime(LocalTime.MAX)
+//        );
+//
+//        if (recent.isEmpty()) {
+//            throw new GlobalException(ErrorCode.STATS_NOT_FOUND);
+//        }
+//
+//        List<RecentStatsResponse.SalesStats> list = recent.stream()
+//                .map(stat -> new RecentStatsResponse.SalesStats(
+//                        stat.getTimestamp().toLocalDate(),
+//                        stat.getTotalSales(),
+//                        stat.getTotalOrders()))
+//                .toList();
+//
+//        return new RecentStatsResponse(list);
+//    }
+//
+//    public TopProductsResponse getTopProducts() {
+//        LocalDate today = LocalDate.now();
+//
+//        List<ProductSalesRanking> salesRankingsRaw =
+//                productSalesRankingRepository.findByDateOrderByTotalSalesDesc(today);
+//
+//        List<ProductSalesRanking> quantityRankingsRaw =
+//                productSalesRankingRepository.findByDateOrderByTotalQuantityDesc(today);
+//
+//        if (salesRankingsRaw.isEmpty() && quantityRankingsRaw.isEmpty()) {
+//            throw new GlobalException(ErrorCode.PRODUCT_SALES_RANKING_NOT_FOUND);
+//        }
+//
+//        List<TopProductsResponse.ProductRanking> salesRankings = salesRankingsRaw.stream()
+//                .limit(5)
+//                .map(r -> new TopProductsResponse.ProductRanking(
+//                        r.getRanking(),
+//                        r.getProductName(),
+//                        r.getTotalSales(),
+//                        r.getTotalQuantity()))
+//                .toList();
+//
+//        List<TopProductsResponse.ProductRanking> quantityRankings = quantityRankingsRaw.stream()
+//                .limit(5)
+//                .map(r -> new TopProductsResponse.ProductRanking(
+//                        r.getRanking(),
+//                        r.getProductName(),
+//                        r.getTotalSales(),
+//                        r.getTotalQuantity()))
+//                .toList();
+//
+//        return new TopProductsResponse(salesRankings, quantityRankings);
+//    }
 }

--- a/src/main/java/io/groom/scubadive/shoppingmall/stats/service/StatsQueryService.java
+++ b/src/main/java/io/groom/scubadive/shoppingmall/stats/service/StatsQueryService.java
@@ -1,7 +1,5 @@
 package io.groom.scubadive.shoppingmall.stats.service;
 
-import io.groom.scubadive.shoppingmall.global.exception.ErrorCode;
-import io.groom.scubadive.shoppingmall.global.exception.GlobalException;
 import io.groom.scubadive.shoppingmall.stats.domain.DailyStats;
 import io.groom.scubadive.shoppingmall.stats.domain.HourlyStats;
 import io.groom.scubadive.shoppingmall.stats.domain.ProductSalesRanking;
@@ -17,12 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## 🔀 PR 제목

- [Feature] 통계 기능 전체 구현

---

## 📌 작업 내용 요약

- 시간 단위 매출 데이터를 저장하는 HourlyStats 도메인 및 저장 메서드 구현
- 일별 통계를 저장하는 DailyStats 도메인 및 생성 스케줄러 구현
- 자정 기준으로 전날 00:00 ~ 23:59 매출을 집계하여 DailyStats에 저장
- GET /api/stats/today : 오늘의 매출 및 주문 수를 조회 (DailyStats 또는 HourlyStats 기준)
- GET /api/stats/recent : 최근 3일간의 일별 통계 조회 (오늘, 어제, 그제 기준)
- 오늘의 상품 판매 랭킹을 위한 ProductSalesRanking 도메인 정의 및 스케줄러 구현
- GET /api/stats/top-products : 오늘의 상품 판매 랭킹을 금액/수량 기준으로 반환
- 랭킹 저장 시 기존 랭킹 삭제 후 새로 저장 (중복 방지)
- 로그 상세 출력 추가 (주문 수, 그룹핑 상품 목록, 랭킹 결과 등)

---

## ✅ 체크리스트

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

예시:
- Closes #65 
- Related to #22 #37 #35

---

## 📎 기타 참고 사항

- 상품 판매 랭킹은 ProductOption의 색상 등과 관계없이 Product 단위로 집계됨
- 운영 환경에서는 HourlyStats는 30분 간격, DailyStats는 자정 5분 후 실행됨
- 스케줄러 테스트를 위해 cron = "*/10 * * * * *" 식으로 임시 변경 가능
